### PR TITLE
Fix array-value conversion in paramsToQueryString()

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -297,7 +297,7 @@ class Client
             }
             if (is_array($value)) {
                 if (empty($value)) {
-                    $query_string[] = $name;
+	                // skip empty arrays
                     continue;
                 }
                 foreach ($value as $key => $item) {

--- a/src/Client.php
+++ b/src/Client.php
@@ -296,15 +296,18 @@ class Client
                 continue;
             }
             if (is_array($value)) {
-                // recursion case
-
-                $result_string = $this->paramsToQueryString($value);
-                if (!empty($result_string)) {
-                    $query_string[] = $result_string;
+                if (empty($value)) {
+                    $query_string[] = $name;
+                    continue;
+                }
+                foreach ($value as $key => $item) {
+                    if (! is_string($key)) {
+                        $key = $name;
+                    }
+                    $item           = (string) $item;
+                    $query_string[] = $key . '=' . rawurlencode($item);
                 }
             } else {
-                // base case
-
                 $value = (string)$value;
                 $query_string[] = $name . '=' . rawurlencode($value);
             }

--- a/tests/GeoNames/ClientTest.php
+++ b/tests/GeoNames/ClientTest.php
@@ -54,6 +54,59 @@ final class ClientTest extends TestCase
     }
 
 
+    public function testParamsToQueryString()
+    {
+        $g = $this->client;
+
+        $class = new \ReflectionClass($g);
+        $method = $class->getMethod('paramsToQueryString');
+        $method->setAccessible(true);
+
+        $paramsToQueryString = static function (array $params = []) use ($method, $g) {
+            return $method->invokeArgs($g, [$params]);
+        };
+
+        $params = [];
+        $qs = $paramsToQueryString($params);
+        $this->assertEquals('', $qs);
+
+        $params =['q' => 'foo'];
+        $qs = $paramsToQueryString($params);
+        $this->assertEquals('q=foo', $qs);
+
+        $params =['q' => ['foo', 'bar']];
+        $qs = $paramsToQueryString($params);
+        $this->assertEquals('q=foo&q=bar', $qs);
+
+        $params =['name_equals' => 'Grüningen', 'country' => 'CH'];
+        $qs = $paramsToQueryString($params);
+        $this->assertEquals('name_equals=Gr%C3%BCningen&country=CH', $qs);
+
+        $params =['name_equals' => 'Grüningen', 'country' => ['CH']];
+        $qs = $paramsToQueryString($params);
+        $this->assertEquals('name_equals=Gr%C3%BCningen&country=CH', $qs);
+
+        $arr = $g->search($params);
+        $this->assertIsArray($arr);
+        $this->assertArrayHasKey(0, $arr);
+
+        $params =['name_equals' => 'Grüningen', 'country' => ['CH', 'DE']];
+        $qs = $paramsToQueryString($params);
+        $this->assertEquals('name_equals=Gr%C3%BCningen&country=CH&country=DE', $qs);
+
+        $arr = $g->search($params);
+        $this->assertIsArray($arr);
+        $this->assertArrayHasKey(0, $arr);
+
+        $params =['name_equals' => 'Grüningen', 'country' => []];
+        $qs = $paramsToQueryString($params);
+        $this->assertEquals('name_equals=Gr%C3%BCningen', $qs);
+
+        $arr = $g->search($params);
+        $this->assertIsArray($arr);
+        $this->assertArrayHasKey(0, $arr);
+    }
+
     public function testAstergram()
     {
         $obj = $this->client->astergdem([


### PR DESCRIPTION
According to https://www.geonames.org/export/geonames-search.html, several parameters can be added multiple times, e.g. `country`, `featureClass`, and `featureCode`.

Since the properties are passed as an array, the only way to pass multiple countries is to pass an array of countries. However, this array is not correctly translated into a repetition of the same parameter.

This patch fixes that, so that e.g.

```
[ 'country' => ['AD', 'CH','UK'] ]
```
would correctly translate into
```
country=AD&country=CH&country=UK
```
instead of the current result:
```
0=AD&1=CH&2=UK
```

(Happy to add or change the pull request if required.)